### PR TITLE
Default Horizonal Scrolling for Character Builder Sheet Options 

### DIFF
--- a/css/black-flag.css
+++ b/css/black-flag.css
@@ -416,6 +416,7 @@
 .black-flag.actor.characterBuilder .options {
     flex: 3;
     overflow-x: scroll;
+    overflow-y: hidden;
     max-width: 1260px;
     flex-wrap: nowrap;
     height: 955px;

--- a/system/apps/forms/character-builder.mjs
+++ b/system/apps/forms/character-builder.mjs
@@ -58,6 +58,22 @@ export default class CharacterBuilderForm extends FormApplication {
         html.on("click", "button", async (event) => await this._onButtonClick(event));
         html.on("click", "a.content-link", async (event) => await this._onClickContentLink(event));
         html.on("input", "input[name='system.talents']", (event) => this._onTalentInputChange(event));
+        
+        //Adds Horizonal Scrolling to the section .options part of the sheet by default for users
+        const scrollContainer = document.querySelector(".options");
+        scrollContainer.addEventListener("wheel", (event) => {
+
+            // Check if the mouse is over an element with the "info" class
+            const isMouseOverInfo = event.target.closest(".info") !== null;
+
+            //early exit out of this event, to allow for vertical scrolling of the options info
+            if (isMouseOverInfo) {
+                return;
+            }
+            event.preventDefault();
+            scrollContainer.scrollLeft += event.deltaY;
+          
+        });
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
While users can already scroll a webpage element with Shift+Scrolling, this may be unintuitive to users who do not know this is an option. Additionally the primary scrolling axis of the Character Builder Options section is already along the Horizonal Axis. I think this will make for a cleaner user experiencer with a mouse and scroll wheel.

While the users mouse is within the div.info part of the builder, which does have vertical scrolling, the horizonal scrolling event that I used will be returned.

I also hide the scrollbar for the Section.options, as it is unused and looks messy.