### PR TITLE
ci: add lint check to pull requests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,33 @@
+name: Checks
+
+on:
+  - pull_request
+
+env:
+  node_version: 18
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - name: Install dependencies
+        run: npm ci --cache .npm --prefer-offline
+
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
Adds a new `checks.yml` file for running workflows on PR.
Uses node 18 to run `npm run lint` when a PR is opened.