### PR TITLE
feat: add target data model

### DIFF
--- a/system/CONSTANTS.mjs
+++ b/system/CONSTANTS.mjs
@@ -9,6 +9,20 @@ function log(...args) {
   if ( isDebugging() ) console.log(`${SYSTEM_NAME} |`, ...args);
 }
 
+const DISTANCE_UNITS = {
+  ft: {label: "ft"},
+  mi: {label: "mi"}
+};
+
+const AREA_OF_EFFECT_TYPES = {
+  sphere: {label: "sphere"},
+  cylinder: {label: "cylinder"},
+  cone: {label: "cone"},
+  square: {label: "square"},
+  cube: {label: "cube"},
+  line: {label: "line"}
+};
+
 /**
  * The supported skill types.
  * @type {{label: string}}
@@ -173,8 +187,8 @@ const TALENT_CATEGORIES = {
  */
 const HIT_DIE_TYPES = {
   d6: {label: "d6"},
-  d10: {label: "d10"},
-}
+  d10: {label: "d10"}
+};
 
 /**
  * The supported ability types.
@@ -186,7 +200,7 @@ const ABILITY_TYPES = {
   intelligence: {label: "Intelligence", shorthand: "INT"},
   wisdom: {label: "Wisdom", shorthand: "WIS"},
   charisma: {label: "Charisma", shorthand: "CHA"}
-}
+};
 
 /**
  * Given a level, return the XP required to the level.
@@ -243,6 +257,8 @@ export const SYSTEM = {
   RACE_SIZE_TYPES,
   ALIGNMENT_TYPES,
   EQUIPMENT_SIZES,
+  DISTANCE_UNITS,
+  AREA_OF_EFFECT_TYPES,
   TALENT_CATEGORIES,
   BACKGROUND_DOCUMENTS: new Collection(),
   HERITAGE_DOCUMENTS: new Collection(),

--- a/system/CONSTANTS.mjs
+++ b/system/CONSTANTS.mjs
@@ -9,11 +9,19 @@ function log(...args) {
   if ( isDebugging() ) console.log(`${SYSTEM_NAME} |`, ...args);
 }
 
+/**
+ * The expected distance units.
+ * @type {{label: string}}
+ */
 const DISTANCE_UNITS = {
   ft: {label: "ft"},
   mi: {label: "mi"}
 };
 
+/**
+ * The expected power area of effect types.
+ * @type {{label: string}}
+ */
 const AREA_OF_EFFECT_TYPES = {
   sphere: {label: "sphere"},
   cylinder: {label: "cylinder"},

--- a/system/datamodels/item/common/target.mjs
+++ b/system/datamodels/item/common/target.mjs
@@ -1,0 +1,80 @@
+/**
+ * Data model template for a Target, as may be used by Powers
+ *
+ * @property {string} type
+ *
+ * @property {object} range
+ * @property {string} range.type
+ * @property {string} range.unit
+ * @property {number} range.value
+ *
+ * @property {object} areaOfEffect
+ * @property {number} areaOfEffect.primaryDimension
+ * @property {number} areaOfEffect.secondaryDimension
+ * @property {string} areaOfEffect.type
+ * @property {string} areaOfEffect.unit
+ *
+ * @property {object} targets
+ * @property {boolean} areaOfEffect.affectsObjects
+ * @property {string} areaOfEffect.creatures
+ * @property {number} areaOfEffect.numberOfChoices
+ *
+ * @mixin
+ */
+export default class TargetDataModel extends foundry.abstract.DataModel {
+
+  /** @inheritdoc */
+  static _enableV10Validation = true;
+
+  /** @inheritDoc */
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return {
+      // Required if type === 'aoe'
+      areaOfEffect: new fields.SchemaField({
+        primaryDimension: new fields.NumberField(),
+        secondaryDimension: new fields.NumberField(),
+        type: new fields.StringField({
+          choices: CONFIG.SYSTEM.AREA_OF_EFFECT_TYPES
+        }),
+        unit: new fields.StringField({
+          choices: CONFIG.SYSTEM.DISTANCE_UNITS,
+          initial: "ft"
+        })
+      }),
+
+      // Required if type !== 'self'
+      range: new fields.SchemaField({
+        type: new fields.StringField({
+          initial: "distance",
+          choices: ["distance" | "touch" | "unlimited"]
+        }),
+        // Required if type === 'distance'
+        unit: new fields.StringField({
+          choices: CONFIG.SYSTEM.DISTANCE_UNITS,
+          initial: "ft"
+        }),
+        // Required if type === 'distance'
+        value: new fields.NumberField()
+      }),
+
+      // Required if type !== 'self'
+      targets: new fields.SchemaField({
+        affectsObjects: new fields.BooleanField({
+          required: true,
+          initial: false
+        }),
+        creatures: new fields.StringField({
+          choices: ["all", "allies", "enemies", "choice", "none"]
+        }),
+        // Required if creatures === 'choice'
+        numberOfChoices: new fields.NumberField()
+      }),
+
+      type: new fields.StringField({
+        required: true,
+        choices: ["self" | "within-range" | "aoe"]
+      })
+    };
+  }
+}

--- a/system/datamodels/item/common/target.mjs
+++ b/system/datamodels/item/common/target.mjs
@@ -73,7 +73,7 @@ export default class TargetDataModel extends foundry.abstract.DataModel {
 
       type: new fields.StringField({
         required: true,
-        choices: ["self" | "within-range" | "aoe"]
+        choices: ["self", "within-range", "aoe"]
       })
     };
   }


### PR DESCRIPTION
Conditional Requirement might be wierd, it doesn't look like data models support this out of the box.

## Examples
> Magic Missile
> Range: 120ft
> ...three darts that each hit a creature of your choice you can see within range

```
{
  type: 'within-range',
  range: {
    type: 'distance',
    unit: 'ft',
    value: 120,
  },
  targets: {
    affectsObjects: false,
    creatures: 'choice',
    numberOfChoices: 3,
  }
}
```

--------------------------------------------

> Mage Armor
> Range: Touch
> ...one willing creature you touch

```
{
  type: 'within-range',,
  range: {
    type: 'touch',
  },
  targets: {
    affectsObjects: false,
    creatures: 'choice',
    numberOfChoices: 1,
  }
}
```

--------------------------------------------

> Comprehend Languages
> Range: Self
```
{
  type: 'self',
}
```

--------------------------------------------

> Detect Magic
> Range: Self
> ..you sense the presence of magic within 30 feet of you
> ...any visible creature or object

```
{
  type: 'within-range',
  range: {
    type: 'distance',
    unit: 'ft',
    value: 30,
  },
  targets: {
    affectsObjects: true,
    creatures: 'all',
  }
}
```

--------------------------------------------

> Fireball (Assuming unchanged from SRD 5.1)
> Range: 150ft
> ...Each creature in a 20-foot-radius sphere centered on that point
> ...ignites flammable objects in the area that aren’t being worn or carried

```
{
  type: 'aoe',
  areaOfEffect: {
    primaryDimension: 20,
    type: 'sphere',
    unit: 'ft',
  },
  range: {
    type: 'distance',
    unit: 'ft',
    value: 150,
  },
  targets: {
    affectsObjects: true,
    creatures: 'all',
  }
}
```

> Scrying (Assuming unchanged from SRD 5.1)
> Range: Self
> ...a particular creature you choose that is on the same plane of existence as you

```
{
  type: 'within-range',
  range: {
    type: 'unlimited',
  },
  targets: {
    affectsObjects: false,
    creatures: 'choice',
    numberOfChoices: 1,
  }
}
```