### PR TITLE
Set default value for `CONFIG.SYSTEM.CLASS_DOCUMENTS`

### DIFF
--- a/system/CONSTANTS.mjs
+++ b/system/CONSTANTS.mjs
@@ -226,6 +226,7 @@ export const SYSTEM = {
   BACKGROUND_DOCUMENTS: new Collection(),
   HERITAGE_DOCUMENTS: new Collection(),
   LINEAGE_DOCUMENTS: new Collection(),
+  CLASS_DOCUMENTS: new Collection(),
   SAVE_TYPES,
   XP_TABLE,
   CHARACTER_BUILDER_MODES


### PR DESCRIPTION
Currently `BlackFlagActor` will assign a value to `CONFIG.SYSTEM.CLASS_DOCUMENTS` only if `CONFIG.SYSTEM.BACKGROUND_DOCUMENTS` is empty. This is not guaranteed, so subsequent checks of `CLASS_DOCUMENTS` are at risk of throwing unhandled exceptions if no actor has called its own `#loadForeignDocuments` method.