### PR TITLE
Fix setting of `result#value` in `mapManualData`

### DIFF
--- a/system/documents/actor.mjs
+++ b/system/documents/actor.mjs
@@ -246,7 +246,7 @@ export default class BlackFlagActor extends Actor {
       result.source = "Manual";
       result.sourceType = "manual";
       result.value = value;
-      result.label = types[value].label;
+      result.label = types[value.value].label;
       return result;
     }
     this.system.proficiencies = this.system.proficiencies.map(p => mapManualData(CONFIG.SYSTEM.PROFICIENCY_TYPES, p));


### PR DESCRIPTION
The `value` parameter is an object with its own `value` property, and this property is the key of `types`.